### PR TITLE
Update signin.jade

### DIFF
--- a/app/views/bootstrap3-templates/signin.jade
+++ b/app/views/bootstrap3-templates/signin.jade
@@ -28,9 +28,10 @@ html(lang='en')
         h2.form-signin-heading Please sign in
         input.form-control(type='email', placeholder='Email address', required='', autofocus='')
         input.form-control(type='password', placeholder='Password', required='')
-        label.checkbox
-          input(type='checkbox', value='remember-me')
-          |  Remember me
+        .checkbox
+            label
+                input(type='checkbox', value='remember-me')
+                |  Remember me
         button.btn.btn-lg.btn-primary.btn-block(type='submit') Sign in
     // /container
     


### PR DESCRIPTION
The remember me check box is not currently aligned with the other form elements Updated the jade template to correctly structure the official template found https://getbootstrap.com/examples/signin/. Now everything aligns correctly.